### PR TITLE
⚙️ Add `capitalized-comments` rule to `core.js`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -35,6 +35,15 @@ export default {
         allow: [],
       },
     ],
+    'capitalized-comments': [
+      'error',
+      'always',
+      {
+        ignoreInlineComments: false,
+        ignoreConsecutiveComments: false,
+        ignorePattern: '',
+      },
+    ],
     'class-methods-use-this': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #44

## How

* Without note comment.
