### PR TITLE
⚙️ Add `dot-notation` rule to `core.js`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -83,6 +83,13 @@ export default {
     'default-param-last': [
       'error',
     ],
+    'dot-notation': [
+      'error',
+      {
+        allowKeywords: true,
+        allowPattern: '',
+      },
+    ],
     eqeqeq: [
       'error',
       'always',


### PR DESCRIPTION
## Why

* Close #46

