### PR TITLE
🐛 Fix `no-octal-escape` and  `no-plusplus` rules in `core.js`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -475,9 +475,9 @@ export default {
       'error',
     ],
     'no-octal-escape': [
-      {
-        'error  no-plusplus': null,
-      },
+      'error',
+    ],
+    'no-plusplus': [
       'error',
       {
         allowForLoopAfterthoughts: false,


### PR DESCRIPTION
## Why

* Close #59
