### PR TITLE
⚙️ Add `no-warning-comments` rule to `core.js`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -771,6 +771,18 @@ export default {
       'error',
       'always',
     ],
+    'no-warning-comments': [
+      'error',
+      {
+        terms: [
+          'todo',
+          'fixme',
+          'xxx',
+        ],
+        location: 'start',
+        decoration: [],
+      },
+    ],
     'openreachtech/empty-line-after-super': [
       'error',
     ],


### PR DESCRIPTION
## Why

* Close #74 

