### PR TITLE
⚙️ Add `no-extra-parens` rule to `stylistic/js.js`

### DIFF
--- a/rules/plugins/statistic/js.js
+++ b/rules/plugins/statistic/js.js
@@ -240,6 +240,21 @@ export default {
         onlyOneSimpleParam: false,
       },
     ],
+    '@stylistic/no-extra-parens': [
+      'error',
+      'all',
+      {
+        conditionalAssign: false,
+        returnAssign: false,
+        nestedBinaryExpressions: false,
+        ignoreJSX: 'none',
+        enforceForArrowConditionals: false,
+        enforceForSequenceExpressions: false,
+        enforceForNewInMemberExpressions: false,
+        enforceForFunctionPrototypeMethods: false,
+        allowParensAfterCommentPattern: '',
+      },
+    ],
     '@stylistic/no-extra-semi': [
       'error',
     ],


### PR DESCRIPTION
## Why

* Close #98 

