### PR TITLE
⚙️ Add `operator-linebreak` rule to `stylistic/js.js`

### DIFF
--- a/rules/plugins/statistic/js.js
+++ b/rules/plugins/statistic/js.js
@@ -390,6 +390,13 @@ export default {
       'error',
       'initializations',
     ],
+    '@stylistic/operator-linebreak': [
+      'error',
+      'after',
+      {
+        overrides: {},
+      },
+    ],
     '@stylistic/padded-blocks': [
       'error',
       'always',


### PR DESCRIPTION
## Why

* Close #99 
