### PR TITLE
⚙️ Add `indent-binary-ops` rule to `stylistic/plus.js`

### DIFF
--- a/rules/plugins/statistic/plus.js
+++ b/rules/plugins/statistic/plus.js
@@ -5,5 +5,9 @@ export default {
     '@stylistic': stylistic,
   },
   rules: {
+    '@stylistic/indent-binary-ops': [
+      'error',
+      2,
+    ],
   },
 }


### PR DESCRIPTION
## Why

* Close #106