### PR TITLE
⚙️ Add `jsdoc/implements-on-classes` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -111,6 +111,16 @@ export default {
         tags: [],
       },
     ],
+    'jsdoc/implements-on-classes': [
+      'error',
+      {
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/imports-as-dependencies': [
       'error',
     ],


### PR DESCRIPTION
## Why

* Close #135

