### PR TITLE
⚙️ Add `jsdoc/no-defaults` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -199,6 +199,17 @@ export default {
         enableFixer: false,
       },
     ],
+    'jsdoc/no-defaults': [
+      'error',
+      {
+        noOptionalParamNames: false,
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/no-missing-syntax': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #140

