### PR TITLE
⚙️ Add `jsdoc/require-description` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -251,6 +251,23 @@ export default {
         tags: {},
       },
     ],
+    'jsdoc/require-description': [
+      'error',
+      {
+        checkConstructors: true,
+        checkGetters: true,
+        checkSetters: true,
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+        descriptionStyle: 'body',
+        exemptedBy: [
+          'inheritdoc',
+        ],
+      },
+    ],
     'jsdoc/require-description-complete-sentence': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #142