### PR TITLE
⚙️ Add `jsdoc/require-example` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -276,6 +276,24 @@ export default {
         tags: [],
       },
     ],
+    'jsdoc/require-example': [
+      'error',
+      {
+        checkConstructors: true,
+        checkGetters: false,
+        checkSetters: false,
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+        enableFixer: true,
+        exemptedBy: [
+          'inheritdoc',
+        ],
+        exemptNoArguments: false,
+      },
+    ],
     'jsdoc/require-file-overview': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #143
