### PR TITLE
⚙️ Add `jsdoc/require-param-name` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -367,6 +367,16 @@ export default {
         setDefaultDestructuredRootDescription: false,
       },
     ],
+    'jsdoc/require-param-name': [
+      'error',
+      {
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/require-param-type': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #147
