### PR TITLE
⚙️ Add `jsdoc/require-returns` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -396,6 +396,23 @@ export default {
     'jsdoc/require-property-type': [
       'error',
     ],
+    'jsdoc/require-returns': [
+      'error',
+      {
+        checkConstructors: false,
+        checkGetters: true,
+        exemptedBy: [
+          'inheritdoc',
+        ],
+        forceRequireReturn: false,
+        forceReturnsWithAsync: false,
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/require-returns-check': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #150
