### PR TITLE
⚙️ Add `jsdoc/require-returns-description` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -421,6 +421,16 @@ export default {
         reportMissingReturnForUndefinedTypes: false,
       },
     ],
+    'jsdoc/require-returns-description': [
+      'error',
+      {
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/require-yields-check': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #152