### PR TITLE
⚙️ Add `jsdoc/require-returns-type` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -431,6 +431,16 @@ export default {
         ],
       },
     ],
+    'jsdoc/require-returns-type': [
+      'error',
+      {
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/require-yields-check': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #154

