### PR TITLE
⚙️ Add `jsdoc/require-throw` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -441,6 +441,19 @@ export default {
         ],
       },
     ],
+    'jsdoc/require-throws': [
+      'error',
+      {
+        exemptedBy: [
+          'inheritdoc',
+        ],
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
+      },
+    ],
     'jsdoc/require-yields-check': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #156
