### PR TITLE
⚙️ Add `jsdoc/text-escaping` rule to `jsdoc.js`

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -666,6 +666,14 @@ export default {
         tags: {},
       },
     ],
+    'jsdoc/text-escaping': [
+      'error',
+      // Must include either `escapeHTML` or `escapeMarkdown` (or both).
+      {
+        escapeHTML: false,
+        escapeMarkdown: false,
+      },
+    ],
     'jsdoc/valid-types': [
       'error',
       {


### PR DESCRIPTION
## Why

* Close #162 
