### PR TITLE
🐛 Fix default value of `contexts` in `jsdoc/no-types` rule

### DIFF
--- a/rules/plugins/jsdoc.js
+++ b/rules/plugins/jsdoc.js
@@ -233,7 +233,11 @@ export default {
     'jsdoc/no-types': [
       'error',
       {
-        contexts: [],
+        contexts: [
+          'ArrowFunctionExpression',
+          'FunctionDeclaration',
+          'FunctionExpression',
+        ],
       },
     ],
     'jsdoc/no-undefined-types': [


### PR DESCRIPTION
## Why

* Close #169
