### PR TITLE
💪 Retake `eslint.config.js` with main exports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,3 @@
-import jestPlugin from 'eslint-plugin-jest'
-import jsdocPlugin from 'eslint-plugin-jsdoc'
 import openreachtechPlugin from 'eslint-plugin-openreachtech'
 
 import ruleHash from './index.js'
@@ -7,7 +5,7 @@ import ruleHash from './index.js'
 /**
  * ESLint Config
  *
- * @type {Array<import('eslint').Linter.FlatConfig>}
+ * @type {Array<import('eslint').LintjestPluginer.FlatConfig>}
  */
 export default [
   {
@@ -1560,7 +1558,7 @@ export default [
     },
   },
   {
-    ...jestPlugin.configs['flat/recommended'],
+    ...ruleHash.jest,
 
     rules: {
       ...ruleHash.jest.rules,
@@ -1772,8 +1770,9 @@ export default [
   },
   {
     plugins: {
-      jsdoc: jsdocPlugin,
+      ...ruleHash.jsdoc.plugins,
     },
+
     rules: {
       ...ruleHash.jsdoc.rules,
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-import core from './rules/core'
-import disableCoreStylistic from './rules/disable-core-stylistic'
-import stylisticJs from './rules/plugins/stylistic/js'
-import stylisticPlus from './rules/plugins/stylistic/plus'
-import jestPlugin from './rules/plugins/jest'
-import jsdocPlugin from './rules/plugins/jsdoc'
+import core from './rules/core.js'
+import disableCoreStylistic from './rules/disable-core-stylistic.js'
+import stylisticJs from './rules/plugins/stylistic/js.js'
+import stylisticPlus from './rules/plugins/stylistic/plus.js'
+import jestPlugin from './rules/plugins/jest.js'
+import jsdocPlugin from './rules/plugins/jsdoc.js'
 
 export default {
   core,


### PR DESCRIPTION
## Why

* Close #188

## How

* Retake `eslint.config.js` with main exports
* Fix import path in main exports
