### PR TITLE
🐛 Add all-in-one stylistic type to `types/index.d.ts`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,12 +5,14 @@ import {
 declare module '@openreachtech/eslint-rules-default' {
   const core: ESLint.ConfigData
   const disableCoreStylistic: ESLint.ConfigData
+  const stylistic: ESLint.ConfigData
   const stylisticJs: ESLint.ConfigData
   const stylisticPlus: ESLint.ConfigData
 
   export = {
     core,
     disableCoreStylistic,
+    stylistic,
     stylisticJs,
     stylisticPlus,
   }


### PR DESCRIPTION
## Why

* Close #295
