### PR TITLE
🧹 Fix warning in `configurations/stylistic/all.js`

### DIFF
--- a/configurations/stylistic/all.js
+++ b/configurations/stylistic/all.js
@@ -9,7 +9,7 @@ export default {
   },
 
   rules: {
-    ...stylistic.configs['all-flat'].rules,
+    ...stylistic.configs.all.rules,
 
     ...jsRules,
     ...plusRules,


### PR DESCRIPTION
# Why

* Close #331
