### PR TITLE
🧩 Resolve JSDoc of default exporting value in `eslint.config.js`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ const jestFlatConfigRecommended = jestPlugin.configs['flat/recommended']
 /**
  * ESLint Config
  *
- * @type {Array<import('eslint').Linter.FlatConfig>}
+ * @type {Array<import('eslint').Linter.Config<*>>} - ESLint configuration
  */
 export default [
   {


### PR DESCRIPTION
# Why

* Close #337
