### PR TITLE
🧹 Kick out `README.ja.md` from `files` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "files": [
     "index.js",
-    "README.ja.md",
     "configurations/",
     "types/"
   ],


### PR DESCRIPTION
# Why

* Close #352