### PR TITLE
📦️ Update the package version to `2.0.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreachtech/eslint-rules-default",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreachtech/eslint-rules-default",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/js": "^9.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreachtech/eslint-rules-default",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A showcasing package all the rules of ESLint.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Bump the package version from `2.0.1` to `2.0.2`, in `package.json` and in the two version fields of `package-lock.json`, ahead of publishing to npmjs.

Close #389